### PR TITLE
CL 3.x support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,13 @@ platforms:
       box: cumulus-vx-2.5.3
       box_url: 'https://objects.dreamhost.com/public-github/vagrant/boxes/cumulus-vx-2.5.3-chef-vbox.box'
       provision: true
-      vagrantfiles: ['test/provision-chef.rb']
+      vagrantfiles: ['test/provision_chef.rb']
+  - name: cumulus-vx-3.3.2
+    driver:
+      box: cumulus-vx-3.3.2
+      box_url: 'http://cumulusfiles.s3.amazonaws.com/cumulus-linux-3.3.2-vx-amd64.box'
+      provision: true
+      vagrantfiles: ['test/provision_chef_cl3.rb']
 
 suites:
   - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 0.1.6 (TBD)
+## 2.1.0 (TBD):
+
+Features:
+  - Cumulus Linux 3.x support (@floored1585)
+
+Code Cleanup:
+  - Style fixes (@floored1585)
+
+## 0.1.6 (???):
 
 Features:
   - add the following support in ::base to interface and interface-range:

--- a/README.md
+++ b/README.md
@@ -127,9 +127,6 @@ Attribute        | Description |Type | Default
 `['xmit_hash_policy']` | TX hashing policy. | String | `layer3+4`
 `['lacp_rate']` | LACP bond rate. | Integer | `1`
 `['lacp_bypass_allow']` | Enable LACP bypass. Set to `1` to enable (*needs to be boolean*). | Integer | `nil`
-`['lacp_bypass_period']` | LACP bypass period. | Integer | `nil`
-`['lacp_bypass_priority']` | String-in-array (*needs to be string*) of interfaces and priorities for LACP bypass priority mode. | Array | `nil`
-`['lacp_bypass_all_active']` | Enable all-active mode for LACP bypass. Set to `1` to enable (*needs to be boolean*). | Integer | `nil`
 `['mstpctl_portnetwork']` | Enable bridge assurance on a VLAN aware trunk. | Boolean | `nil`
 `['mstpctl_portadminedge']` | Enables admin edge port. | Boolean | `nil`
 `['mstpctl_bpduguard']` | Enable BPDU guard on a VLAN aware trunk. | Boolean | `nil`
@@ -148,10 +145,12 @@ Attribute        | Description |Type | Default
 cumulus-switch::mgmt_vrf
 ---
 
+NOTE! With Cumulus Linux 3.x, this recipe can simply be included; no need to set any attributes.
+
 Attribute        | Description |Type | Default
 -----------------|-------------|-----|--------
-`node['cumulus']['mgmt_vrf']['enabled']` | Enables or disables management VRF ([documentation](http://docs.cumulusnetworks.com/display/DOCS/Management+VRF)).  Note: this is `nil` by default, which causes no actions to be taken.  `true` will install and configure the management vrf. `false` will remove the package and disable the management vrf. | Boolean | `nil`
-`node['cumulus']['mgmt_vrf']['restart_quagga']` | Restart Quagga if management VRF status changes. | Boolean | `nil`
+`node['cumulus']['mgmt_vrf']['enabled']` | In Cumulus Linux 2.x, this enables or disables management VRF ([documentation](http://docs.cumulusnetworks.com/display/DOCS/Management+VRF)).  Note: this is `nil` by default, which causes no actions to be taken.  `true` will install and configure the management vrf. `false` will remove the package and disable the management vrf. | Boolean | `nil`
+`node['cumulus']['mgmt_vrf']['restart_quagga']` | In Cumulus Linux 2.x, this restarts Quagga if management VRF status changes. | Boolean | `nil`
 
 Usage
 =====

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['recipes','attributes','test/integration/default/serverspec']
+  task.patterns = ['recipes', 'attributes', 'test/integration/default/serverspec']
   task.options = ['--display-cop-names']
 end
 
@@ -11,18 +11,18 @@ begin
 
   Kitchen::RakeTasks.new
 
-  desc "Install Berkshelf cookbooks for testing"
+  desc 'Install Berkshelf cookbooks for testing'
   task :berks_install do
     begin
-      berksfile = Berkshelf::Berksfile.from_file("Berksfile")
+      berksfile = Berkshelf::Berksfile.from_file('Berksfile')
       berksfile.install
     rescue StandardError => e
       STDERR.puts("Failed to install Chef cookbooks: #{e.message}")
     end
   end
 
-  desc "Converge and run tests"
-  task :test => [:berks_install, 'kitchen:all'] do
+  desc 'Converge and run tests'
+  task test: [:berks_install, 'kitchen:all'] do
   end
 rescue LoadError
   puts "Couldn't load test-kitchen: kitchen tests are not available"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-default['cumulus']['interfaces']['dir'] = ::File.join('','etc','network','interfaces.d')
+default['cumulus']['interfaces']['dir'] = ::File.join('', 'etc', 'network', 'interfaces.d')

--- a/libraries/util.rb
+++ b/libraries/util.rb
@@ -161,15 +161,13 @@ module Cumulus
       #   Interface to retrieve
       #
       def if_to_hash(name)
-        begin
-          json = ''
-          IO.popen("ifquery #{name} -o json") do |ifquery|
-            json = ifquery.read
-          end
-          return JSON.load(json)
-        rescue StandardError => ex
-          Chef::Log.fatal("failed to run ifquery for interface #{name}:  #{ex}")
+        json = ''
+        IO.popen("ifquery #{name} -o json") do |ifquery|
+          json = ifquery.read
         end
+        return JSON.load(json)
+      rescue StandardError => ex
+        Chef::Log.fatal("failed to run ifquery for interface #{name}:  #{ex}")
       end
 
       ##
@@ -198,20 +196,18 @@ module Cumulus
       # an array.
       #
       def hash_to_if(name, hash)
-        begin
-          intf = ''
-          IO.popen("ifquery -i - -t json #{name}", 'r+') do |ifquery|
-            ifquery.write(hash.to_json)
-            ifquery.close_write
+        intf = ''
+        IO.popen("ifquery -i - -t json #{name}", 'r+') do |ifquery|
+          ifquery.write(hash.to_json)
+          ifquery.close_write
 
-            intf = ifquery.read
-            ifquery.close
-          end
-          Chef::Log.debug("ifquery produced the following:\n#{intf}")
-          return intf
-        rescue StandardError => ex
-          Chef::Log.fatal("failed to run ifquery -i for interface #{name}:  #{ex}\nInput was #{hash.to_json}")
+          intf = ifquery.read
+          ifquery.close
         end
+        Chef::Log.debug("ifquery produced the following:\n#{intf}")
+        return intf
+      rescue StandardError => ex
+        Chef::Log.fatal("failed to run ifquery -i for interface #{name}:  #{ex}\nInput was #{hash.to_json}")
       end
 
       ##

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
-name             'cumulus-switch'
-maintainer       'Ian Clark'
+name 'cumulus-switch'
+maintainer 'Ian Clark'
 maintainer_email 'ian@f85.net'
-license          'Apache 2.0'
-description      'Configures a Cumulus switch via attributes'
+license 'Apache 2.0'
+description 'Configures a Cumulus switch via attributes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.4'
+version '2.1.0'

--- a/providers/bond.rb
+++ b/providers/bond.rb
@@ -57,57 +57,38 @@ action :create do
   address = ipv4 + ipv6
 
   config = { 'bond-slaves' => slaves.join(' '),
-             'bond-min-links' => min_links,
-             'bond-mode' => mode,
-             'bond-miimon' => miimon,
-             'bond-lacp-rate' => lacp_rate,
-             'bond-xmit-hash-policy' => xmit_hash_policy }
+             'bond-min-links' => min_links.to_s,
+             'bond-mode' => mode.to_s,
+             'bond-miimon' => miimon.to_s,
+             'bond-lacp-rate' => lacp_rate.to_s,
+             'bond-xmit-hash-policy' => xmit_hash_policy.to_s }
 
   # Insert optional parameters
   config['address'] = address unless address.nil?
   # If single address, don't use an array (for ifquery -o json equality test)
   config['address'] = address[0] if address.class == Array && address.count == 1
-  config['alias'] = alias_name unless alias_name.nil?
-  config['mtu'] = mtu unless mtu.nil?
-  config['clag-id'] = clag_id unless clag_id.nil?
+  config['alias'] = alias_name.to_s unless alias_name.nil?
+  config['mtu'] = mtu.to_s unless mtu.nil?
+  config['clag-id'] = clag_id.to_s unless clag_id.nil?
   config['bridge-vids'] = vids unless vids.nil?
-  config['bridge-pvid'] = pvid unless pvid.nil?
+  config['bridge-pvid'] = pvid.to_s unless pvid.nil?
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?
   config['mstpctl-portadminedge'] = Cumulus::Utils.bool_to_yn(mstpctl_portadminedge) unless mstpctl_portadminedge.nil?
   config['mstpctl-bpduguard'] = Cumulus::Utils.bool_to_yn(mstpctl_bpduguard) unless mstpctl_bpduguard.nil?
+  config['bond-lacp-bypass-allow'] = lacp_bypass_allow.to_s unless lacp_bypass_allow.nil?
 
   # Family is always 'inet' if a method is set
   addr_family = addr_method.nil? ? nil : 'inet'
 
-  if lacp_bypass_allow
-    lacp_bypass_period = data['lacp_bypass_period']
-    lacp_bypass_priority = data['lacp_bypass_priority']
-    lacp_bypass_all_active = data['lacp_bypass_all_active']
-
-    # Validate the other options if LACP bypass is enabled
-    if lacp_bypass_allow == '1'
-      if lacp_bypass_priority.nil? && lacp_bypass_all_active.nil?
-        Chef::Application.fatal!('Either lacp_bypass_priority or lacp_bypass_all_active must be set when lacp_bypass_allow is enabled')
-      elsif !lacp_bypass_priority.nil? && !lacp_bypass_all_active.nil?
-        Chef::Application.fatal!('Only one of lacp_bypass_priority or lacp_bypass_all_active must be set when lacp_bypass_allow is enabled')
-      end
-    end
-
-    config['bond-lacp-bypass-allow'] = lacp_bypass_allow
-    config['bond-lacp-bypass-priority'] = lacp_bypass_priority unless lacp_bypass_priority.nil?
-    config['bond-lacp-bypass-all-active'] = lacp_bypass_all_active unless lacp_bypass_all_active.nil?
-    config['bond-lacp-bypass-period'] = lacp_bypass_period unless lacp_bypass_period.nil?
-  end
-
   new = [{ 'auto' => true,
-           'name' => name,
+           'name' => name.to_s,
            'config' => config }]
 
-  new[0]['addr_method'] = addr_method if addr_method
-  new[0]['addr_family'] = addr_family if addr_family
+  new[0]['addr_method'] = addr_method.to_s if addr_method
+  new[0]['addr_family'] = addr_family.to_s if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 

--- a/providers/bridge.rb
+++ b/providers/bridge.rb
@@ -55,13 +55,13 @@ action :create do
   config['address'] = address unless address.nil?
   # If single address, don't use an array (for ifquery -o json equality test)
   config['address'] = address[0] if address.class == Array && address.count == 1
-  config['mtu'] = mtu unless mtu.nil?
-  config['mstpctl-treeprio'] = mstpctl_treeprio unless mstpctl_treeprio.nil?
-  config['alias'] = alias_name unless alias_name.nil?
+  config['mtu'] = mtu.to_s unless mtu.nil?
+  config['mstpctl-treeprio'] = mstpctl_treeprio.to_s unless mstpctl_treeprio.nil?
+  config['alias'] = alias_name.to_s unless alias_name.nil?
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
-  config['vrf'] = vrf unless vrf.nil?
+  config['vrf'] = vrf.to_s unless vrf.nil?
 
   if data['vlan_aware']
     config['bridge-vlan-aware'] = 'yes'
@@ -71,18 +71,18 @@ action :create do
     pvid = data['pvid']
 
     config['bridge-vids'] = vids unless vids.nil?
-    config['bridge-pvid'] = pvid unless pvid.nil?
+    config['bridge-pvid'] = pvid.to_s unless pvid.nil?
   end
 
   # Family is always 'inet' if a method is set
   addr_family = addr_method.nil? ? nil : 'inet'
 
   new = [{ 'auto' => true,
-           'name' => name,
+           'name' => name.to_s,
            'config' => config }]
 
-  new[0]['addr_method'] = addr_method if addr_method
-  new[0]['addr_family'] = addr_family if addr_family
+  new[0]['addr_method'] = addr_method.to_s if addr_method
+  new[0]['addr_family'] = addr_family.to_s if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 

--- a/providers/bridge.rb
+++ b/providers/bridge.rb
@@ -36,6 +36,7 @@ action :create do
   pre_down = data['pre_down']
   virtual_ip = data['virtual_ip']
   virtual_mac = data['virtual_mac']
+  vrf = data['vrf']
 
   # Default to 'true' if no value provided
   stp = data['stp']
@@ -60,6 +61,7 @@ action :create do
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless post_up.nil?
+  config['vrf'] = vrf unless vrf.nil?
 
   if data['vlan_aware']
     config['bridge-vlan-aware'] = 'yes'

--- a/providers/interface.rb
+++ b/providers/interface.rb
@@ -43,6 +43,8 @@ action :create do
   virtual_mac = data['virtual_mac']
   virtual_ip = data['virtual_ip']
   vids = data['vids']
+  vrf = data['vrf']
+  vrf_table = data['vrf_table']
   pvid = data['pvid']
   clagd_enable = data['clagd_enable']
   mstpctl_portnetwork = data['mstpctl_portnetwork']
@@ -69,6 +71,8 @@ action :create do
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?
   config['mstpctl-portadminedge'] = Cumulus::Utils.bool_to_yn(mstpctl_portadminedge) unless mstpctl_portadminedge.nil?
   config['mstpctl-bpduguard'] = Cumulus::Utils.bool_to_yn(mstpctl_bpduguard) unless mstpctl_bpduguard.nil?
+  config['vrf'] = vrf unless vrf.nil?
+  config['vrf-table'] = vrf_table unless vrf_table.nil?
 
   # Insert CLAG parameters if CLAG is enabled
   if clagd_enable

--- a/providers/interface.rb
+++ b/providers/interface.rb
@@ -61,18 +61,18 @@ action :create do
   config['address'] = address unless address.nil?
   # If single address, don't use an array (for ifquery -o json equality test)
   config['address'] = address[0] if address.class == Array && address.count == 1
-  config['alias'] = alias_name unless alias_name.nil?
-  config['mtu'] = mtu unless mtu.nil?
+  config['alias'] = alias_name.to_s unless alias_name.nil?
+  config['mtu'] = mtu.to_s unless mtu.nil?
   config['bridge-vids'] = vids unless vids.nil?
-  config['bridge-pvid'] = pvid unless pvid.nil?
+  config['bridge-pvid'] = pvid.to_s unless pvid.nil?
   config['address-virtual'] = [virtual_mac, virtual_ip].compact.join(' ') unless virtual_ip.nil? && virtual_mac.nil?
   config['post-up'] = post_up unless post_up.nil?
   config['pre-down'] = pre_down unless pre_down.nil?
   config['mstpctl-portnetwork'] = Cumulus::Utils.bool_to_yn(mstpctl_portnetwork) unless mstpctl_portnetwork.nil?
   config['mstpctl-portadminedge'] = Cumulus::Utils.bool_to_yn(mstpctl_portadminedge) unless mstpctl_portadminedge.nil?
   config['mstpctl-bpduguard'] = Cumulus::Utils.bool_to_yn(mstpctl_bpduguard) unless mstpctl_bpduguard.nil?
-  config['vrf'] = vrf unless vrf.nil?
-  config['vrf-table'] = vrf_table unless vrf_table.nil?
+  config['vrf'] = vrf.to_s unless vrf.nil?
+  config['vrf-table'] = vrf_table.to_s unless vrf_table.nil?
 
   # Insert CLAG parameters if CLAG is enabled
   if clagd_enable
@@ -82,14 +82,14 @@ action :create do
     clagd_args = data['clagd_args']
 
     config['clagd-enable'] = 'yes'
-    config['clagd-peer-ip'] = clagd_peer_ip unless clagd_peer_ip.nil?
-    config['clagd-priority'] = clagd_priority unless clagd_priority.nil?
-    config['clagd-sys-mac'] = clagd_sys_mac unless clagd_sys_mac.nil?
+    config['clagd-peer-ip'] = clagd_peer_ip.to_s unless clagd_peer_ip.nil?
+    config['clagd-priority'] = clagd_priority.to_s unless clagd_priority.nil?
+    config['clagd-sys-mac'] = clagd_sys_mac.to_s unless clagd_sys_mac.nil?
     config['clagd-args'] = "\"#{clagd_args}\"" unless clagd_args.nil?
   end
 
   unless speed.nil?
-    config['link-speed'] = speed
+    config['link-speed'] = speed.to_s
     # link-duplex is always set to 'full' if link-speed is set
     config['link-duplex'] = 'full'
   end
@@ -98,11 +98,11 @@ action :create do
   addr_family = addr_method.nil? ? nil : 'inet'
 
   new = [{ 'auto' => true,
-           'name' => name,
+           'name' => name.to_s,
            'config' => config }]
 
-  new[0]['addr_method'] = addr_method if addr_method
-  new[0]['addr_family'] = addr_family if addr_family
+  new[0]['addr_method'] = addr_method.to_s if addr_method
+  new[0]['addr_family'] = addr_family.to_s if addr_family
 
   current = Cumulus::Utils.if_to_hash(name)
 

--- a/providers/license.rb
+++ b/providers/license.rb
@@ -49,9 +49,7 @@ end
 # Parse the provided source URI and stop executation if the URL is invalid
 #
 def validate_url!(uri_str)
-  begin
-    URI.parse(uri_str)
-  rescue URI::InvalidURIError
-    Chef::Application.fatal!("The cumulus_license source URL #{uri_str} is invalid")
-  end
+  URI.parse(uri_str)
+rescue URI::InvalidURIError
+  Chef::Application.fatal!("The cumulus_license source URL #{uri_str} is invalid")
 end

--- a/recipes/base.rb
+++ b/recipes/base.rb
@@ -8,11 +8,20 @@ include_recipe 'cumulus-switch'
 
 # cl_interface is used for interface ranges and individual interfaces
 def cl_interface(interface, data, range=nil)
+  #if interface == 'eth0' && data['vrf'] == 'mgmt'
+  #  service 'snmpd@mgmt'
+  #end
   cumulus_switch_interface interface do
     range range if range
 
     notifies :run, 'execute[reload_networking]', :delayed if node['cumulus']['reload_networking']
     notifies :run, 'execute[reload_loopback]', :delayed if interface =~ /^lo/
+    #if interface == 'eth0' && data['vrf'] == 'mgmt'
+    #  notifies :stop, 'service[snmpd]', :immediately
+    #  notifies :disable, 'service[snmpd]', :immediately
+    #  notifies :enable, 'service[snmpd@mgmt]', :immediately
+    #  notifies :start, 'service[snmpd@mgmt]'
+    #end
   end
 end
 

--- a/recipes/interfaces.rb
+++ b/recipes/interfaces.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 service 'networking' do
-  supports :status => true, :restart => true, :reload => true
+  supports status: true, restart: true, reload: true
   action :nothing
 end
 
@@ -36,7 +36,7 @@ end
   config = ::File.join(location, intf)
   execute "#{intf} config" do
     command "ifquery #{intf} > #{config}"
-    not_if { ::File.exists?(config) }
+    not_if { ::File.exist?(config) }
     notifies :reload, 'service[networking]'
   end
 end

--- a/recipes/isc-dhcp-relay.rb
+++ b/recipes/isc-dhcp-relay.rb
@@ -26,7 +26,7 @@ if node['dhcp_relay']
     )
     notifies :restart, "service[#{relay_service}]", :delayed
   end
-  service relay_service do 
-    action [ :enable, :start ]
+  service relay_service do
+    action [:enable, :start]
   end
 end

--- a/recipes/isc-dhcp-relay.rb
+++ b/recipes/isc-dhcp-relay.rb
@@ -4,6 +4,15 @@
 #
 # Copyright 2015, DreamHost
 #
+
+release = node['lsb']['release']
+case release
+when /^3\./
+  relay_service = 'dhcrelay'
+else
+  relay_service = 'isc-dhcp-relay'
+end
+
 if node['dhcp_relay']
   # Servers are seperated with a space, as well as interfaces
   servers = node['dhcp_relay']['servers']
@@ -15,7 +24,9 @@ if node['dhcp_relay']
       servers: servers,
       interfaces: interfaces
     )
-    notifies :restart, 'service[isc-dhcp-relay]', :delayed
+    notifies :restart, "service[#{relay_service}]", :delayed
   end
-  service 'isc-dhcp-relay'
+  service relay_service do 
+    action [ :enable, :start ]
+  end
 end

--- a/recipes/mgmt_vrf.rb
+++ b/recipes/mgmt_vrf.rb
@@ -29,7 +29,7 @@ release = node['lsb']['release']
 case release
 when /^3\./
   node.default['cumulus']['interface']['eth0']['vrf'] = 'mgmt'
-  node.default['cumulus']['interface']['mgmt']['ipv4'] = [ '127.0.0.1/8' ]
+  node.default['cumulus']['interface']['mgmt']['ipv4'] = ['127.1.0.1/16']
   node.default['cumulus']['interface']['mgmt']['vrf_table'] = 'auto'
   include_recipe 'cumulus-switch::base'
 else

--- a/recipes/mgmt_vrf.rb
+++ b/recipes/mgmt_vrf.rb
@@ -29,7 +29,7 @@ release = node['lsb']['release']
 case release
 when /^3\./
   node.default['cumulus']['interface']['eth0']['vrf'] = 'mgmt'
-  node.default['cumulus']['interface']['mgmt']['ipv4'] = ['127.1.0.1/16']
+  node.default['cumulus']['interface']['mgmt']['ipv4'] = ['127.0.0.1/8']
   node.default['cumulus']['interface']['mgmt']['vrf_table'] = 'auto'
   include_recipe 'cumulus-switch::base'
 else

--- a/recipes/switchd.rb
+++ b/recipes/switchd.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 service 'switchd' do
-  supports :status => true, :restart => true
+  supports status: true, restart: true
   action :nothing
 end

--- a/test/cookbooks/cumulus-switch-test/metadata.rb
+++ b/test/cookbooks/cumulus-switch-test/metadata.rb
@@ -1,8 +1,7 @@
-name             'cumulus-switch-test'
-maintainer       'Ian Clark'
+name 'cumulus-switch-test'
+maintainer 'Ian Clark'
 maintainer_email 'ian@f85.net'
-description      'Installs/Configures cumulus-switch-test'
+description 'Installs/Configures cumulus-switch-test'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
-
-depends         'cumulus-switch'
+version '0.1.0'
+depends 'cumulus-switch'

--- a/test/cookbooks/cumulus-switch-test/recipes/bonds.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/bonds.rb
@@ -9,8 +9,6 @@ node.set['cumulus']['bond']['bond1']['ipv4'] = ['10.0.0.1/24', '192.168.1.0/16']
 node.set['cumulus']['bond']['bond1']['ipv6'] = ['2001:db8:abcd::/48']
 node.set['cumulus']['bond']['bond1']['clag_id'] = 1
 node.set['cumulus']['bond']['bond1']['lacp_bypass_allow'] = 1
-node.set['cumulus']['bond']['bond1']['lacp_bypass_period'] = 30
-node.set['cumulus']['bond']['bond1']['lacp_bypass_all_active'] = 1
 node.set['cumulus']['bond']['bond1']['virtual_ip'] = '192.168.20.1'
 node.set['cumulus']['bond']['bond1']['virtual_mac'] = '11:22:33:44:55:FF'
 node.set['cumulus']['bond']['bond1']['mstpctl_portnetwork'] = true
@@ -28,15 +26,14 @@ node.set['cumulus']['bond']['bond1']['clag_id'] = 1
 node.set['cumulus']['bond']['bond1']['vids'] = ['1-4094']
 node.set['cumulus']['bond']['bond1']['pvid'] = 1
 node.set['cumulus']['bond']['bond1']['post_up'] = [
-  "ip route add 10.0.0.0/8 via 192.168.200.2",
-  "ip route add 172.16.0.0/12 via 192.168.200.2"
+  'ip route add 10.0.0.0/8 via 192.168.200.2',
+  'ip route add 172.16.0.0/12 via 192.168.200.2'
 ]
 node.set['cumulus']['bond']['bond1']['pre_down'] = [
-  "ip route del 10.0.0.0/8 via 192.168.200.2",
-  "ip route del 172.16.0.0/12 via 192.168.200.2"
+  'ip route del 10.0.0.0/8 via 192.168.200.2',
+  'ip route del 172.16.0.0/12 via 192.168.200.2'
 ]
 
 node.set['cumulus']['bond']['bond2']['slaves'] = ['swp7', 'swp8']
 node.set['cumulus']['bond']['bond2']['virtual_ip'] = '11:22:33:44:55:FF 192.168.20.1'
 node.set['cumulus']['bond']['bond2']['lacp_bypass_allow'] = 1
-node.set['cumulus']['bond']['bond2']['lacp_bypass_priority'] = ['swp7=10 swp8=5']

--- a/test/cookbooks/cumulus-switch-test/recipes/bridges.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/bridges.rb
@@ -32,10 +32,10 @@ node.set['cumulus']['bridge']['bridge3']['mtu'] = 9000
 node.set['cumulus']['bridge']['bridge3']['stp'] = false
 node.set['cumulus']['bridge']['bridge3']['mstpctl_treeprio'] = 4096
 node.set['cumulus']['bridge']['bridge3']['post_up'] = [
-  "ip route add 10.0.0.0/8 via 192.168.200.2",
-  "ip route add 172.16.0.0/12 via 192.168.200.2"
+  'ip route add 10.0.0.0/8 via 192.168.200.2',
+  'ip route add 172.16.0.0/12 via 192.168.200.2'
 ]
 node.set['cumulus']['bridge']['bridge3']['pre_down'] = [
-  "ip route del 10.0.0.0/8 via 192.168.200.2",
-  "ip route del 172.16.0.0/12 via 192.168.200.2"
+  'ip route del 10.0.0.0/8 via 192.168.200.2',
+  'ip route del 172.16.0.0/12 via 192.168.200.2'
 ]

--- a/test/cookbooks/cumulus-switch-test/recipes/default.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/default.rb
@@ -12,13 +12,13 @@ end
 
 node.set['cumulus']['reload_networking'] = false
 
-include_recipe "cumulus-switch-test::ports"
-include_recipe "cumulus-switch-test::license"
-include_recipe "cumulus-switch-test::interface_policy"
-include_recipe "cumulus-switch-test::bonds"
-include_recipe "cumulus-switch-test::bridges"
-include_recipe "cumulus-switch-test::interfaces"
-include_recipe "cumulus-switch-test::mgmt_vrf"
+include_recipe 'cumulus-switch-test::ports'
+include_recipe 'cumulus-switch-test::license'
+include_recipe 'cumulus-switch-test::interface_policy'
+include_recipe 'cumulus-switch-test::bonds'
+include_recipe 'cumulus-switch-test::bridges'
+include_recipe 'cumulus-switch-test::interfaces'
+include_recipe 'cumulus-switch-test::mgmt_vrf'
 
 include_recipe 'cumulus-switch::base'
 include_recipe 'cumulus-switch::mgmt_vrf'

--- a/test/cookbooks/cumulus-switch-test/recipes/interfaces.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/interfaces.rb
@@ -21,17 +21,17 @@ node.set['cumulus']['interface']['swp2']['mstpctl_portnetwork'] = true
 node.set['cumulus']['interface']['swp2']['mstpctl_portadminedge'] = true
 node.set['cumulus']['interface']['swp2']['mstpctl_bpduguard'] = true
 node.set['cumulus']['interface']['swp2']['post_up'] = [
-  "ip route add 10.0.0.0/8 via 192.168.200.2",
-  "ip route add 172.16.0.0/12 via 192.168.200.2"
+  'ip route add 10.0.0.0/8 via 192.168.200.2',
+  'ip route add 172.16.0.0/12 via 192.168.200.2'
 ]
 node.set['cumulus']['interface']['swp2']['pre_down'] = [
-  "ip route del 10.0.0.0/8 via 192.168.200.2",
-  "ip route del 172.16.0.0/12 via 192.168.200.2"
+  'ip route del 10.0.0.0/8 via 192.168.200.2',
+  'ip route del 172.16.0.0/12 via 192.168.200.2'
 ]
 
 # Test post_up and pre_down as String instead of Array
-node.set['cumulus']['interface']['swp3']['post_up'] = "ip route add 192.168.0.0/16 via 192.168.200.2"
-node.set['cumulus']['interface']['swp3']['pre_down'] = "ip route del 192.168.0.0/16 via 192.168.200.2"
+node.set['cumulus']['interface']['swp3']['post_up'] = 'ip route add 192.168.0.0/16 via 192.168.200.2'
+node.set['cumulus']['interface']['swp3']['pre_down'] = 'ip route del 192.168.0.0/16 via 192.168.200.2'
 
 # CLAGD
 node.set['cumulus']['interface']['swp4']['clagd_enable'] = true

--- a/test/cookbooks/cumulus-switch-test/recipes/mgmt_vrf.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/mgmt_vrf.rb
@@ -2,5 +2,11 @@
 # Cookbook Name:: cumulus-switch-test
 # Recipe:: mgmt_vrf
 #
-node.set['cumulus']['mgmt_vrf']['enabled'] = true
-node.set['cumulus']['mgmt_vrf']['restart_quagga'] = true
+if node['lsb']['release'] =~ /^3\./
+  # TODO: Is there some way to reliably test Management VRF with CL 3? I just get disconnected during the chef run.
+  #include_recipe 'cumulus-switch::mgmt_vrf'
+else
+  node.set['cumulus']['mgmt_vrf']['enabled'] = true
+  node.set['cumulus']['mgmt_vrf']['restart_quagga'] = true
+end
+

--- a/test/cookbooks/cumulus-switch-test/recipes/ports.rb
+++ b/test/cookbooks/cumulus-switch-test/recipes/ports.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: cumulus-switch-test
 # Recipe:: ports
 #
-node.set['cumulus']['ports']['10g'] = ['swp1']
-node.set['cumulus']['ports']['40g'] = ['swp2-3']
-node.set['cumulus']['ports']['40g_div_4'] = ['swp4', 'swp5']
-node.set['cumulus']['ports']['4_by_10g'] = ['swp6', 'swp7-8']
+node.set['cumulus']['ports']['10g'] = %w( 'swp1' )
+node.set['cumulus']['ports']['40g'] = %w( 'swp2-3' )
+node.set['cumulus']['ports']['40g_div_4'] = %w( 'swp4', 'swp5' )
+node.set['cumulus']['ports']['4_by_10g'] = %w( 'swp6', 'swp7-8' )

--- a/test/integration/default/serverspec/bonds_spec.rb
+++ b/test/integration/default/serverspec/bonds_spec.rb
@@ -25,8 +25,6 @@ describe file("#{intf_dir}/bond1") do
   its(:content) { should match(/bond-miimon 99/) }
   its(:content) { should match(/bond-lacp-rate 9/) }
   its(:content) { should match(/bond-lacp-bypass-allow 1/) }
-  its(:content) { should match(/bond-lacp-bypass-period 30/) }
-  its(:content) { should match(/bond-lacp-bypass-all-active 1/) }
   its(:content) { should match(/bond-min-links 2/) }
   its(:content) { should match(/bridge-vids 1-4094/) }
   its(:content) { should match(/bridge-pvid 1/) }
@@ -48,6 +46,6 @@ end
 describe file("#{intf_dir}/bond2") do
   it { should be_file }
   its(:content) { should match(/iface bond2/) }
-  its(:content) { should match(/swp7=10 swp8=5/) }
+  its(:content) { should match(/swp7 swp8/) }
   its(:content) { should match(/address-virtual 11:22:33:44:55:FF 192.168.20.1/) }
 end

--- a/test/integration/default/serverspec/mgmt_vrf_spec.rb
+++ b/test/integration/default/serverspec/mgmt_vrf_spec.rb
@@ -3,10 +3,12 @@ require 'serverspec'
 set :backend, :exec
 set :path, '/bin:/usr/bin:/sbin/usr/sbin'
 
-describe package('cl-mgmtvrf') do
-  it { should be_installed }
+if /^2\./.match os[:release]
+  describe package('cl-mgmtvrf') do
+    it { should be_installed }
+  end
+  describe command('ip route show table mgmt') do
+    its(:exit_status) { should eq 0 }
+  end
 end
 
-describe command('ip route show table mgmt') do
-  its(:exit_status) { should eq 0 }
-end

--- a/test/provision-chef.rb
+++ b/test/provision-chef.rb
@@ -1,3 +1,0 @@
-Vagrant.configure("2") do |config|
-  config.vm.provision :shell, inline: "apt-get update && apt-get install chef && ln -s /usr/bin/chef-solo /bin/chef-solo"
-end

--- a/test/provision_chef.rb
+++ b/test/provision_chef.rb
@@ -1,0 +1,3 @@
+Vagrant.configure('2') do |config|
+  config.vm.provision :shell, inline: 'apt-get update && apt-get install chef && ln -s /usr/bin/chef-solo /bin/chef-solo'
+end

--- a/test/provision_chef_cl3.rb
+++ b/test/provision_chef_cl3.rb
@@ -1,0 +1,3 @@
+Vagrant.configure('2') do |config|
+  config.vm.provision :shell, inline: 'wget --quiet https://packages.chef.io/files/stable/chef/12.21.3/debian/8/chef_12.21.3-1_amd64.deb && dpkg -i chef_12.21.3-1_amd64.deb && ln -s /usr/bin/chef-solo /bin/chef-solo'
+end


### PR DESCRIPTION
A lot of changes, and a lot of cleanup.  Tests are passing for CL 3.x and 2.x.  Unable to test Management VRF with CL 3.x due to disconnection during chef run (not sure what the solution is there).